### PR TITLE
[FIX] vercel rewrite 설정

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
- 배포 시 베이스 url을 제외한 url은 인식하지 못하는 문제가 있음.
- 해결 방법이 두 가지가 있었으나 rewrite를 사용하여 해결함.
1) routes 설정
- 공식문서에서 이렇게 말하고 있음.
`We recommend using [cleanUrls], [trailingSlash], [redirects], [rewrites], and/or [headers] instead.`
- 아마 라우팅의 여러 목적을 분리하기 위해서..??이지 않을까
```
{
  "routes": [
    { "src": "/[^.]+", "dest": "/", "status": 200 }
  ]
}
```

2) rewrites 설정
- 모든 url 요청을 '/'로 변환
- 프록시 서버 만들 때도 rewrites 사용
```
{
  "rewrites": [
    { "source": "/(.*)", "destination": "/" }
  ]
}
```

- 참고 자료
https://vercel.com/docs/projects/project-configuration#routes
