### PR TITLE
[FIX] # 링크 사용 시 페이지 전환 안되는 문제 해결

### DIFF
--- a/src/hooks/useNavigation.ts
+++ b/src/hooks/useNavigation.ts
@@ -4,15 +4,15 @@ export const useNavigation = () => {
   const navigate = useNavigate();
 
   const toMain = () => {
-    navigate('/');
+    navigate('/', { replace: true });
   };
 
   const toSignIn = () => {
-    navigate('/signin');
+    navigate('/signin', { replace: true });
   };
 
   const toSignUp = () => {
-    navigate('/signup');
+    navigate('/signup', { replace: true });
   };
 
   return {

--- a/src/pages/SignIn/index.tsx
+++ b/src/pages/SignIn/index.tsx
@@ -54,6 +54,12 @@ export const SignInPage = () => {
     }
   };
 
+  const onClickTBD = () => {
+    toast('아직 없는 기능이에요.', {
+      icon: '🔔',
+    });
+  };
+
   if (isPending) return <LoadingPage />;
 
   return (
@@ -101,12 +107,12 @@ export const SignInPage = () => {
                 className="py-1 border-b-2 border-gray text-sm focus:outline-none focus:border-orange"
               />
             </div>
-            <div className="FindIdPwWrapper flex justify-left text-sm text-gray-400 py-4 gap-2">
-              <a href="#" className="hover:text-orange underline">
+            <div className="FindIdPwWrapper flex justify-left text-sm text-gray-500 py-4 gap-2">
+              <a onClick={onClickTBD} className="hover:text-orange underline">
                 아이디 찾기
               </a>
               <span>|</span>
-              <a href="#" className="hover:text-orange underline">
+              <a onClick={onClickTBD} className="hover:text-orange underline">
                 비밀번호 찾기
               </a>
             </div>


### PR DESCRIPTION
- 비밀번호 변경 또는 아이디 찾기 a 태그를 누르고 로그인하면 제대로 전환이 안되는 문제가 있음.
- '#'으로 이동하지 않도록 바꾸니 정상적으로 작동함. 대신 클릭 시 "아직 구현한 기능이 아닙니다" 토스트가 뜨도록 변경함.
- 혹시 몰라서 navigate에 replace도 추가해놓음. (url 전환 시 강제로 페이지 리로드)
- 왜 그럴까..?
예상 이유) a 태그에 의해 페이지가 자동으로 새로고침됨.
리액트 라우터에 의해 조정되는 방식이 아니라 브라우저에서 강제로 리로드 -> 여기에서 꼬인 것이 아닐까 추정 (?)
확실한 이유는 모르겠음.

+) React Router Dom에서 Link 컴포넌트를 사용해서도 실험해봤는데 아예 anchor가 안먹는 듯
놀랍게도 라이브러리 깔아야 함..
https://www.npmjs.com/package/react-router-hash-link