### PR TITLE
[FIX] 재로그인을 실행할 때 무효 토큰 삭제 및 로그아웃

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,11 +49,7 @@ const routers = createBrowserRouter([
     path: PATH.INDEX,
     element: (
       <AuthProtectedSwitchRoute
-        authorized={
-          <AuthProtectedRoute>
-            <MainPage />
-          </AuthProtectedRoute>
-        }
+        authorized={<MainPage />}
         unauthorized={<LandingPage />}
       />
     ),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -165,8 +165,8 @@ export const App = () => {
   };
 
   // 모달 창 닫아주는 함수를 context api를 사용하여 관리
-  const closeModal = () => {
-    setIsTokenError(false);
+  const setOpen = (isOpen: boolean) => {
+    setIsTokenError(isOpen);
   };
 
   return (
@@ -174,7 +174,7 @@ export const App = () => {
       <ServiceContext.Provider value={services}>
         <TokenManageContext.Provider value={manageToken}>
           <ModalManageContext.Provider
-            value={{ isModalOpen: isTokenError, closeModal }}
+            value={{ isModalOpen: isTokenError, setOpen }}
           >
             <TokenAuthContext.Provider value={{ token }}>
               <RouterProvider router={routers} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 
 import type { CallParams } from '@/api';
 import { impleSnuttApi } from '@/api';
-import { AuthProtectedRoute } from '@/components/Auth';
-import { PATH, ROUTE_TYPE } from '@/constants/route';
+import { PATH } from '@/constants/route';
 import { EnvContext } from '@/context/EnvContext';
 import { ModalManageContext } from '@/context/ModalManageContext';
 import { ServiceContext } from '@/context/ServiceContext';
@@ -29,28 +28,35 @@ import { getAuthService } from '@/usecases/authServices';
 import { getUserService } from '@/usecases/userService';
 import { showDialog } from '@/utils/showDialog';
 
+import {
+  AuthProtectedRoute,
+  AuthProtectedSwitchRoute,
+} from './components/Auth';
+
 // 어떠한 경로로 요청하더라도 Landing Page로 이동할 수 있도록 함.
 // 무효 토큰을 막아야 하는 페이지는 AuthProtectedRoute 사용
 
-const routes = [
+const routers = createBrowserRouter([
   {
     path: PATH.SIGNIN,
     element: <SignInPage />,
-    type: ROUTE_TYPE.ALL,
   },
   {
     path: PATH.SIGNUP,
     element: <SignUpPage />,
-    type: ROUTE_TYPE.ALL,
   },
   {
     path: PATH.INDEX,
     element: (
-      <AuthProtectedRoute>
-        <MainPage />
-      </AuthProtectedRoute>
+      <AuthProtectedSwitchRoute
+        authorized={
+          <AuthProtectedRoute>
+            <MainPage />
+          </AuthProtectedRoute>
+        }
+        unauthorized={<LandingPage />}
+      />
     ),
-    type: ROUTE_TYPE.SIGNIN,
   },
   {
     path: PATH.MYPAGE,
@@ -59,31 +65,12 @@ const routes = [
         <MyPage />
       </AuthProtectedRoute>
     ),
-    type: ROUTE_TYPE.SIGNIN,
-  },
-  {
-    path: '/*',
-    element: <LandingPage />,
-    type: ROUTE_TYPE.UNSIGNIN,
   },
   {
     path: '/*',
     element: <NotFoundPage />,
-    type: ROUTE_TYPE.SIGNIN,
   },
-];
-
-const UnSignInRoutes = routes.filter(
-  (route) =>
-    route.type === ROUTE_TYPE.ALL || route.type === ROUTE_TYPE.UNSIGNIN,
-);
-
-const SignInRoutes = routes.filter(
-  (route) => route.type === ROUTE_TYPE.ALL || route.type === ROUTE_TYPE.SIGNIN,
-);
-
-const UnSignInRouter = createBrowserRouter(UnSignInRoutes);
-const SignInRouter = createBrowserRouter(SignInRoutes);
+]);
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -193,13 +180,9 @@ export const App = () => {
           <ModalManageContext.Provider
             value={{ isModalOpen: isTokenError, closeModal }}
           >
-            {token !== null ? (
-              <TokenAuthContext.Provider value={{ token }}>
-                <RouterProvider router={SignInRouter} />
-              </TokenAuthContext.Provider>
-            ) : (
-              <RouterProvider router={UnSignInRouter} />
-            )}
+            <TokenAuthContext.Provider value={{ token }}>
+              <RouterProvider router={routers} />
+            </TokenAuthContext.Provider>
             <Toaster position="bottom-center" />
           </ModalManageContext.Provider>
         </TokenManageContext.Provider>

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -19,5 +19,9 @@ export const AuthProtectedSwitchRoute = ({
   unauthorized: ReactNode;
 }) => {
   const { token } = useGuardContext(TokenAuthContext);
-  return token !== null ? <>{authorized}</> : <>{unauthorized}</>;
+  return token !== null ? (
+    <AuthProtectedRoute>{authorized}</AuthProtectedRoute>
+  ) : (
+    <>{unauthorized}</>
+  );
 };

--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -1,11 +1,23 @@
 import type { ReactNode } from 'react';
 
-import { ReSignInModal } from '@/components/Modal';
-import { ModalManageContext } from '@/context/ModalManageContext';
-import { useGuardContext } from '@/hooks/useGuardContext';
+import { ModalManageContext } from '../context/ModalManageContext';
+import { TokenAuthContext } from '../context/TokenAuthContext';
+import { useGuardContext } from '../hooks/useGuardContext';
+import { ReSignInModal } from './Modal';
 
 export const AuthProtectedRoute = ({ children }: { children: ReactNode }) => {
   const { isModalOpen } = useGuardContext(ModalManageContext);
 
   return isModalOpen ? <ReSignInModal /> : <>{children}</>;
+};
+
+export const AuthProtectedSwitchRoute = ({
+  authorized,
+  unauthorized,
+}: {
+  authorized: ReactNode;
+  unauthorized: ReactNode;
+}) => {
+  const { token } = useGuardContext(TokenAuthContext);
+  return token !== null ? <>{authorized}</> : <>{unauthorized}</>;
 };

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,10 +1,17 @@
-import { useNavigate } from 'react-router-dom';
+import { ServiceContext } from '../context/ServiceContext';
+import { TokenManageContext } from '../context/TokenManageContext';
+import { useGuardContext } from '../hooks/useGuardContext';
+import { useNavigation } from '../hooks/useNavigation';
 
 export const ReSignInModal = () => {
-  const navigate = useNavigate();
+  const { toSignIn } = useNavigation();
+  const { authService } = useGuardContext(ServiceContext);
+  const { clearToken } = useGuardContext(TokenManageContext);
 
   const onClickButton = () => {
-    navigate('/signin');
+    authService.logout();
+    clearToken();
+    toSignIn();
   };
 
   return (

--- a/src/constants/route.ts
+++ b/src/constants/route.ts
@@ -1,9 +1,3 @@
-export const ROUTE_TYPE = {
-  ALL: 'ALL',
-  UNSIGNIN: 'UNSIGNIN',
-  SIGNIN: 'SIGNIN',
-};
-
 export const PATH = {
   INDEX: '/',
   SIGNIN: '/signin',

--- a/src/context/ModalManageContext.ts
+++ b/src/context/ModalManageContext.ts
@@ -2,7 +2,7 @@ import { createContext } from 'react';
 
 type ModalManageContext = {
   isModalOpen: boolean;
-  closeModal(): void;
+  setOpen(isOpen: boolean): void;
 };
 
 export const ModalManageContext = createContext<ModalManageContext | null>(

--- a/src/context/TokenAuthContext.ts
+++ b/src/context/TokenAuthContext.ts
@@ -1,7 +1,7 @@
 import { createContext } from 'react';
 
 type TokenAuthContext = {
-  token: string;
+  token: string | null;
 };
 
 export const TokenAuthContext = createContext<TokenAuthContext | null>(null);

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -17,8 +17,13 @@ export const MainPage = () => {
   const { showErrorDialog } = showDialog();
 
   const { data: userData } = useQuery({
-    queryKey: ['UserService', 'getUserInfo', { token }] as const,
-    queryFn: ({ queryKey }) => userService.getUserInfo(queryKey[2]),
+    queryKey: ['UserService', 'getUserInfo', token] as const,
+    queryFn: ({ queryKey }) => {
+      // token이 null이 아닐 때 실행되도 getUserInfo 안에서는 string | null이 들어갈 수 없음.
+      // 241015 연우: 이렇게 강제로 string 타입을 지정해도 되는지?
+      return userService.getUserInfo({ token: queryKey[2] as string });
+    },
+    enabled: token !== null,
   });
 
   const handleClickContaminateButton = () => {

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -10,21 +10,30 @@ import { TokenManageContext } from '@/context/TokenManageContext';
 import { useGuardContext } from '@/hooks/useGuardContext';
 import { showDialog } from '@/utils/showDialog';
 
+import { ModalManageContext } from '../../context/ModalManageContext';
+
 export const MainPage = () => {
   const { contaminateToken, clearToken } = useGuardContext(TokenManageContext);
+  const { setOpen } = useGuardContext(ModalManageContext);
   const { userService, authService } = useGuardContext(ServiceContext);
   const { token } = useGuardContext(TokenAuthContext);
   const { showErrorDialog } = showDialog();
 
-  const { data: userData } = useQuery({
+  const { data: userData, isError } = useQuery({
     queryKey: ['UserService', 'getUserInfo', token] as const,
-    queryFn: ({ queryKey }) => {
-      // token이 null이 아닐 때 실행되도 getUserInfo 안에서는 string | null이 들어갈 수 없음.
-      // 241015 연우: 이렇게 강제로 string 타입을 지정해도 되는지?
-      return userService.getUserInfo({ token: queryKey[2] as string });
+    queryFn: ({ queryKey: [, , t] }) => {
+      if (t === null) {
+        throw new Error();
+      }
+      return userService.getUserInfo({ token: t });
     },
     enabled: token !== null,
   });
+
+  if (isError) {
+    setOpen(true);
+    return null;
+  }
 
   const handleClickContaminateButton = () => {
     contaminateToken('xxx');

--- a/src/pages/SignIn/index.tsx
+++ b/src/pages/SignIn/index.tsx
@@ -12,7 +12,7 @@ import { useNavigation } from '@/hooks/useNavigation';
 import { showDialog } from '@/utils/showDialog';
 
 export const SignInPage = () => {
-  const { closeModal } = useGuardContext(ModalManageContext);
+  const { setOpen } = useGuardContext(ModalManageContext);
   const [id, setId] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const { toMain } = useNavigation();
@@ -32,7 +32,7 @@ export const SignInPage = () => {
     onSuccess: (response) => {
       if (response.type === 'success') {
         saveToken(response.data.token);
-        closeModal();
+        setOpen(false);
         toMain();
       } else {
         showErrorDialog(response.message);


### PR DESCRIPTION
- 무효토큰을 남겨두는 것보다는 그냥 삭제시키고 로그아웃하는 방식으로 수정
- 이때 token 값이 바뀌면서 접근 가능한 router도 변경됨. -> 이유는 모르겠는데 /signin으로 url이 변경되어도 페이지가 바뀌지 않음. (replace 옵션 적용해도 바뀌지 않음)
- router를 고정시키니까 문제 사라짐. -> 대신 토큰 값으로 null 값도 가질 수 있어서 token을 사용하는 요청이 필요할 떄 추가적인 처리가 필요해짐..

근데 코드를 짤수록 점점 /signin url을 괜히 만들었다는 생각이 듦.
- 뭐가 더 나을지 논의 후 머지