### PR TITLE
token state가 변경될 때 라우터가 비정상적으로 작동하는 오류

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -181,9 +181,8 @@ export const App = () => {
     },
   };
 
-  // 모달 창 닫아주는 함수를 context api를 사용하여 관리
-  const closeModal = () => {
-    setIsTokenError(false);
+  const setModalOpen = (isOpen: boolean) => {
+    setIsTokenError(isOpen);
   };
 
   return (
@@ -191,7 +190,7 @@ export const App = () => {
       <ServiceContext.Provider value={services}>
         <TokenManageContext.Provider value={manageToken}>
           <ModalManageContext.Provider
-            value={{ isModalOpen: isTokenError, closeModal }}
+            value={{ isModalOpen: isTokenError, setModalOpen }}
           >
             {token !== null ? (
               <TokenAuthContext.Provider value={{ token }}>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,10 +1,17 @@
-import { useNavigate } from 'react-router-dom';
+import { ServiceContext } from '../context/ServiceContext';
+import { TokenManageContext } from '../context/TokenManageContext';
+import { useGuardContext } from '../hooks/useGuardContext';
+import { useNavigation } from '../hooks/useNavigation';
 
 export const ReSignInModal = () => {
-  const navigate = useNavigate();
+  const { toSignIn } = useNavigation();
+  const { authService } = useGuardContext(ServiceContext);
+  const { clearToken } = useGuardContext(TokenManageContext);
 
   const onClickButton = () => {
-    navigate('/signin');
+    authService.logout();
+    clearToken();
+    toSignIn();
   };
 
   return (

--- a/src/context/ModalManageContext.ts
+++ b/src/context/ModalManageContext.ts
@@ -2,7 +2,7 @@ import { createContext } from 'react';
 
 type ModalManageContext = {
   isModalOpen: boolean;
-  closeModal(): void;
+  setModalOpen(isOpen: boolean): void;
 };
 
 export const ModalManageContext = createContext<ModalManageContext | null>(

--- a/src/pages/SignIn/index.tsx
+++ b/src/pages/SignIn/index.tsx
@@ -12,7 +12,7 @@ import { useNavigation } from '@/hooks/useNavigation';
 import { showDialog } from '@/utils/showDialog';
 
 export const SignInPage = () => {
-  const { closeModal } = useGuardContext(ModalManageContext);
+  const { setModalOpen } = useGuardContext(ModalManageContext);
   const [id, setId] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const { toMain } = useNavigation();
@@ -32,7 +32,7 @@ export const SignInPage = () => {
     onSuccess: (response) => {
       if (response.type === 'success') {
         saveToken(response.data.token);
-        closeModal();
+        setModalOpen(false);
         toMain();
       } else {
         showErrorDialog(response.message);


### PR DESCRIPTION
- 로그인 -> 잘못된 토큰 저장 -> 모달 팝업 등장 후 "로그인 페이지로 이동" 버튼을 누르면 url은 /signin으로 이동하나 페이지가 변환되지 않음.
- 예상되는 이유: token이 null로 변경예정되고 url이 signup으로 바뀜 -> setToken에 의해 token이 null로 바뀌면서 전체적인 라우터가 변경 -> 중간에 라우터가 아무것도 없는 경우가 생겨서 메인페이지가 나옴(????)

사실 잘 모르겠어요
![image](https://github.com/user-attachments/assets/9e19f4e4-bb10-4350-83e5-e486ed78b266)
