### PR TITLE
[FIX] api 공통 error response 추가

### DIFF
--- a/src/api/apis/api.ts
+++ b/src/api/apis/api.ts
@@ -1,5 +1,5 @@
 import type { impleSnuttApi } from '..';
-import type { ErrorResponse, SuccessResponse } from '../response';
+import type { SuccessResponse } from '../response';
 import type { Api, GetApiSpecsParameter } from '.';
 import type {
   LocalLoginRequest,
@@ -14,9 +14,7 @@ export const getSnuttApis = ({
   ({
     // 로컬 로그인 api
     'POST /v1/auth/login_local': ({ body }: { body: LocalLoginRequest }) =>
-      callWithoutToken<
-        SuccessResponse<LocalLoginResponse> | ErrorResponse<403, 8197>
-      >({
+      callWithoutToken<SuccessResponse<LocalLoginResponse>>({
         method: 'post',
         path: 'v1/auth/login_local',
         body,

--- a/src/api/apis/api.ts
+++ b/src/api/apis/api.ts
@@ -24,7 +24,7 @@ export const getSnuttApis = ({
 
     // 요청한 유저의 정보 전달 api
     'GET /v1/users/me': ({ token }: { token: string }) =>
-      callWithToken<SuccessResponse<UserResponse> | ErrorResponse<403, 8194>>({
+      callWithToken<SuccessResponse<UserResponse>>({
         method: 'get',
         path: 'v1/users/me',
         token,

--- a/src/api/apis/index.ts
+++ b/src/api/apis/index.ts
@@ -20,10 +20,10 @@ type InternalClient = {
 export type GetApiSpecsParameter = {
   callWithToken: <R extends ResponseNecessary>(
     p: Parameters<InternalClient['call']>[0] & { token: string },
-  ) => Promise<R | ErrorResponse<403, 8194>>;
+  ) => Promise<R | ErrorResponse>;
   callWithoutToken: <R extends ResponseNecessary>(
     p: Omit<Parameters<InternalClient['call']>[0], 'token'> & { token?: never },
-  ) => Promise<R>;
+  ) => Promise<R | ErrorResponse>;
 };
 
 export const apis = (client: InternalClient) => {
@@ -36,11 +36,11 @@ export const apis = (client: InternalClient) => {
         token?: string;
     } */
     p: Parameters<InternalClient['call']>[0] & { token: string },
-  ) => client.call<R | ErrorResponse<403, 8194>>(p);
+  ) => client.call<R | ErrorResponse>(p);
 
   const callWithoutToken = <R extends ResponseNecessary>(
     p: Parameters<InternalClient['call']>[0] & { token?: never },
-  ) => client.call<R>(p);
+  ) => client.call<R | ErrorResponse>(p);
 
   const params = { callWithToken, callWithoutToken };
 

--- a/src/api/apis/index.ts
+++ b/src/api/apis/index.ts
@@ -1,4 +1,4 @@
-import type { ResponseNecessary } from '../response';
+import type { ErrorResponse, ResponseNecessary } from '../response';
 import { getSnuttApis } from './api';
 
 export type Api = (_: {
@@ -20,7 +20,7 @@ type InternalClient = {
 export type GetApiSpecsParameter = {
   callWithToken: <R extends ResponseNecessary>(
     p: Parameters<InternalClient['call']>[0] & { token: string },
-  ) => Promise<R>;
+  ) => Promise<R | ErrorResponse<403, 8194>>;
   callWithoutToken: <R extends ResponseNecessary>(
     p: Omit<Parameters<InternalClient['call']>[0], 'token'> & { token?: never },
   ) => Promise<R>;
@@ -36,7 +36,7 @@ export const apis = (client: InternalClient) => {
         token?: string;
     } */
     p: Parameters<InternalClient['call']>[0] & { token: string },
-  ) => client.call<R>(p);
+  ) => client.call<R | ErrorResponse<403, 8194>>(p);
 
   const callWithoutToken = <R extends ResponseNecessary>(
     p: Parameters<InternalClient['call']>[0] & { token?: never },

--- a/src/api/response.ts
+++ b/src/api/response.ts
@@ -13,8 +13,8 @@ export type SuccessResponse<T, Status extends number = 200> = {
 };
 
 export type ErrorResponse<
-  Status extends 400 | 401 | 403 | 404,
-  Errcode extends number,
+  Status extends 400 | 401 | 403 | 404 | 500 = 400 | 401 | 403 | 404 | 500,
+  Errcode extends number = number,
   Ext extends Record<string, never> = Record<string, never>,
 > = {
   status: Status;


### PR DESCRIPTION
- 백엔드에서 errcode 내려주고 있음. -> ErrorResponse<403, 8194> 이렇게 직접 지정할 필요가 없음.
- api 작성 시 SuccessResponse만 넣으면 되도록 공통 ErrorResponse로 수정