### PR TITLE
[FIX] 무한로딩 에러 수정 및 recent timetable 삭제 이후 변경된 시간표에서 선택 버튼 나타나지 않는 오류 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -211,7 +211,7 @@ export const App = () => {
   const [token, setToken] = useState(temporaryStorageRepository.getToken());
 
   const [timetableId, setTimetableId] = useState(
-    timetableStorageRepository.getStorageTimetableId,
+    timetableStorageRepository.getStorageTimetableId(),
   );
 
   const [colorScheme, setColorScheme] = useState<string | null>(() => {

--- a/src/app_pages/Main/Drawer/TimeTableMenuBottomSheet/DeleteDialog.tsx
+++ b/src/app_pages/Main/Drawer/TimeTableMenuBottomSheet/DeleteDialog.tsx
@@ -16,14 +16,14 @@ export const DeleteDialog = ({
 }: {
   onClose(): void;
   timetableId: string;
-  selectedTimetableId: string | undefined;
-  handleClickSetTimetableId: (timetableId: string | undefined) => void;
+  selectedTimetableId: string | null;
+  handleClickSetTimetableId: (timetableId: string | null) => void;
 }) => {
   const { isVisible, handleClose } = useDialog({ onClose });
   const { deleteTimeTable, isPending } = useDeleteTimeTable({
     handleClose,
     selectedTimetableId,
-    handleClickSetTimetableId: handleClickSetTimetableId,
+    handleClickSetTimetableId,
   });
 
   const onClickButton = () => {
@@ -49,8 +49,8 @@ const useDeleteTimeTable = ({
   handleClickSetTimetableId,
 }: {
   handleClose(): void;
-  selectedTimetableId: string | undefined;
-  handleClickSetTimetableId: (timetableId: string | undefined) => void;
+  selectedTimetableId: string | null;
+  handleClickSetTimetableId: (timetableId: string | null) => void;
 }) => {
   const { timeTableService } = useGuardContext(ServiceContext);
   const { token } = useGuardContext(TokenAuthContext);
@@ -63,7 +63,7 @@ const useDeleteTimeTable = ({
         throw new Error('토큰이 존재하지 않습니다.');
       }
       if (timetableId === selectedTimetableId) {
-        handleClickSetTimetableId(undefined);
+        handleClickSetTimetableId(null);
       }
       return await timeTableService.deleteTimeTableById({
         token,

--- a/src/app_pages/Main/Drawer/TimeTableMenuBottomSheet/index.tsx
+++ b/src/app_pages/Main/Drawer/TimeTableMenuBottomSheet/index.tsx
@@ -12,8 +12,8 @@ type TimeTableMenuBottomSheet = {
     title: string;
   };
   onClose(): void;
-  selectedTimetableId: string | undefined;
-  handleClickSetTimetableId: (timetableId: string | undefined) => void;
+  selectedTimetableId: string | null;
+  handleClickSetTimetableId: (timetableId: string | null) => void;
 };
 
 type DialogMenu = 'NAME' | 'DELETE' | 'NONE';

--- a/src/app_pages/Main/Drawer/index.tsx
+++ b/src/app_pages/Main/Drawer/index.tsx
@@ -22,8 +22,8 @@ import { showDialog } from '@/utils/showDialog';
 type Drawer = {
   isOpen: boolean;
   onClose: () => void;
-  selectedTimetableId: string | undefined;
-  handleClickSetTimetableId: (timetableId: string | undefined) => void;
+  selectedTimetableId: string | null;
+  handleClickSetTimetableId: (timetableId: string | null) => void;
 };
 
 type BottomSheetItem = Pick<TimeTableBrief, '_id' | 'title'>;
@@ -39,7 +39,7 @@ export const Drawer = ({
   const { showTBDDialog, showErrorDialog } = showDialog();
   const { timeTableService } = useGuardContext(ServiceContext);
 
-  const setSelectedTimeTableId = (timetableId: string | undefined) => {
+  const setSelectedTimeTableId = (timetableId: string) => {
     handleClickSetTimetableId(timetableId);
     onClose();
   };
@@ -349,7 +349,7 @@ const TimeTableMenuBar = ({
   children,
 }: {
   timeTable: TimeTableBrief;
-  selectedTimeTableId: string | undefined;
+  selectedTimeTableId: string | null;
   onClick(): void;
   children: ReactNode;
 }) => {

--- a/src/app_pages/Main/TimeTable/index.tsx
+++ b/src/app_pages/Main/TimeTable/index.tsx
@@ -14,9 +14,6 @@ export const TimeTableView = ({
   const { timeTableService } = useGuardContext(ServiceContext);
   const { toLectureDetailPage } = useRouteNavigation();
 
-  // 241108 연우: 단순히 token 문제가 아닐 수 있음.
-  // toast로 에러 메세지를 띄워줘야 할 거 같음.
-
   const columnCount = dayList.length - 2;
   const rowCount = hourList.length * 12;
   return (

--- a/src/components/common/HeaderContainer.tsx
+++ b/src/components/common/HeaderContainer.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 export const HeaderContainer = ({ children }: { children: ReactNode }) => {
   return (
     <div
-      className="flex absolute t-0 l-0 w-full justify-between pt-2 pb-1.5 pl-4 p-3 border-b-[1px] border-solid border-b-lineLight bg-white
+      className="flex absolute t-0 l-0 w-full justify-between pt-2 pb-1.5 pl-4 p-3 border-solid border-b-lineLight bg-white
     dark:bg-gray-800 dark:text-gray-200 dark:border-gray-600"
     >
       {children}

--- a/src/context/TimetableContext.ts
+++ b/src/context/TimetableContext.ts
@@ -1,8 +1,8 @@
 import { createContext } from 'react';
 
 type TimetableContext = {
-  timetableId: string | undefined;
-  setTimetableId: (timetableId: string | undefined) => void;
+  timetableId: string | null;
+  setTimetableId: (timetableId: string | null) => void;
 };
 
 export const TimetableContext = createContext<TimetableContext | null>(null);

--- a/src/infrastructure/impleStorageRepository.ts
+++ b/src/infrastructure/impleStorageRepository.ts
@@ -28,7 +28,7 @@ export const implTimetableStorageRepository = (): TimetableRepository => {
   return {
     getStorageTimetableId: () => {
       const timetableId = localStorage.getItem(storageKey.selectedTimetableId);
-      return timetableId !== null ? timetableId : undefined;
+      return timetableId;
     },
     saveStorageTimetableId: (timetableId: string) => {
       localStorage.setItem(storageKey.selectedTimetableId, timetableId);

--- a/src/usecases/timeTableService.ts
+++ b/src/usecases/timeTableService.ts
@@ -30,7 +30,7 @@ type TimeTableRepository = {
 type LectureTime = Lecture['class_time_json'][number];
 
 type TimetableStorageRepository = {
-  getStorageTimetableId: () => string | undefined;
+  getStorageTimetableId: () => string | null;
   saveStorageTimetableId: (id: string) => void;
   clearStorageTimetableId: () => void;
 };
@@ -72,9 +72,8 @@ export type TimeTableService = {
       items: TimeTableBrief[];
     }
   >;
-  storeSelectedTimetableId(_: {
-    selectedTimetableId: string | undefined;
-  }): void;
+  storeSelectedTimetableId(_: { selectedTimetableId: string | null }): void;
+  resetSelectedTimetableId(): void;
 };
 
 export const getTimeTableService = ({
@@ -226,15 +225,14 @@ export const getTimeTableService = ({
     return groupedTimetables;
   },
 
-  storeSelectedTimetableId: ({
-    selectedTimetableId,
-  }: {
-    selectedTimetableId: string | undefined;
-  }) => {
-    if (selectedTimetableId !== undefined) {
+  storeSelectedTimetableId: ({ selectedTimetableId }) => {
+    if (selectedTimetableId !== null) {
       timetableStorageRepository.saveStorageTimetableId(selectedTimetableId);
     } else {
       timetableStorageRepository.clearStorageTimetableId();
     }
+  },
+  resetSelectedTimetableId: () => {
+    timetableStorageRepository.clearStorageTimetableId();
   },
 });


### PR DESCRIPTION
일단 무한로딩은 고쳤는데, 삭제한 이후에 setTimetableId하는 부분에서 문제가 좀 있습니다.
```typescript
export const MainPage = () => {
  const [isDrawerOpen, setDrawerOpen] = useState(false);
  const { toLectureList } = useRouteNavigation();
  const { timetableId, setTimetableId } = useGuardContext(TimetableContext);
  const { timeTableService } = useGuardContext(ServiceContext);
  const { timeTableListData } = useGetTimeTable();
  const { showErrorDialog } = showDialog();

// 현재 timetable을 불러와서 만약 timetableId가 null이라면 timetableListData의 첫번쨰 값 사용
// 근데 생각해보니 timetableListData가 빈 배열이면 다른 페이지를 보여줘야 할 듯
  const currentTimetable = (() => {
    if (timeTableListData === undefined || timeTableListData.type === 'error') {
      return null;
    }
    return timetableId !== null
      ? timeTableListData.data.find((tt) => tt._id === timetableId)
      : timeTableListData.data[0];
  })();

// 수정한 timetableId에 따라 timetableData 불러옴.
// 근데 context Api에 저장된 timetableId는 그대로임. -> 따로 저장되지 않음.
  const { timetableData } = useGetTimetableData({
    timetableId: currentTimetable?._id,
  });


  if (timetableData === undefined) return <LoadingPage />;

  if (timetableData.type === 'error') {
    showErrorDialog(timetableData.message);
    return null;
  }

....
```

그래서 이걸 해결해주려면 바뀐 currentTimetableId를 저장해줘야 되는데,
```typescript
  useEffect(() => {
    if (
      timetableData !== undefined &&
      timetableData.type !== 'error' &&
      timetableId !== timetableData.data._id
    ) {
      timeTableService.storeSelectedTimetableId({
        selectedTimetableId: timetableData.data._id,
      });
      setTimetableId(timetableData.data._id);
    }
  }, [timetableData, timetableId, timeTableService, setTimetableId]);
```
그러려면 엄청나게 불편한 useEffect를 집어넣어야 합니다.