### PR TITLE
[FIX] 코드 수정 이후 css 깨지는 에러 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,3 @@
-import '@/reset.css';
-import '@/index.css';
-
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { Toaster } from 'react-hot-toast';

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,6 @@
+import '@/reset.css';
+import '@/index.css';
+
 export default function RootLayout({
   children,
 }: {


### PR DESCRIPTION
@woohm402
넥스트 자체 버그라고 봐야 될지 좀 애매하긴 한데 일단 import '@/index.css' 를 src/App,tsx 에서 src/app/layout.tsx 로 옮기니까 되네요!

클라이언트 컴포넌트에서 글로벌 스타일 임포트를 지원을 안하는건지 넥스트팀에서 놓친건지는 모르겠지만 일단 src/app/layout.tsx 가 Next.js 에서 올바른 루트 컴포넌트는 맞아서, 저기로 옮겨두면 이슈도 해결되고 넥스트 철학에도 더 맞게 돼서 좋을 것 같습니다

https://wafflestudio2-dqe6104.slack.com/archives/C07KA053CBZ/p1732088287957079?thread_ts=1732005198.107769&cid=C07KA053CBZ